### PR TITLE
fixup to deal with object $@

### DIFF
--- a/lib/Mojolicious/Plugin/RenderCGI.pm
+++ b/lib/Mojolicious/Plugin/RenderCGI.pm
@@ -91,7 +91,7 @@ sub handler {
     
     $$output = $plugin->error(sprintf(qq{Compile time error for template "%s" from the %s: %s}, $name, $from, $err), $c)
       and return
-      unless ref $err; # ref success
+      unless ref $err and $err == $template; # ref success
     
   }
   


### PR DESCRIPTION
There is a $SIG{__DIE__} handler in place which upgrades errors to exception objects. If the compile fails, depending on how, it may or may not fire the handler. In 5.37.4 it will fire, and this logic will break.

Testing against $template is the safest minimal change to this code.